### PR TITLE
option to use imagick in preview generation with extended opts

### DIFF
--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -96,7 +96,6 @@ class Generator {
 			throw new NotFoundException('Cannot read file');
 		}
 
-
 		$this->eventDispatcher->dispatch(
 			IPreview::EVENT,
 			new GenericEvent($file,[

--- a/lib/private/Preview/GeneratorHelper.php
+++ b/lib/private/Preview/GeneratorHelper.php
@@ -32,6 +32,11 @@ use OCP\Image as OCPImage;
 use OCP\Preview\IProvider;
 use OCP\Preview\IProviderV2;
 
+// TODO use autoloader
+require_once 'JPEG.php';
+use OC\Preview\OC_Image_JPEG as OCPImage_JPEG;
+
+
 /**
  * Very small wrapper class to make the generator fully unit testable
  */
@@ -63,8 +68,20 @@ class GeneratorHelper {
 	 * @param ISimpleFile $maxPreview
 	 * @return IImage
 	 */
-	public function getImage(ISimpleFile $maxPreview) {
-		$image = new OCPImage();
+	public function getImage($maxPreview) {
+		$mimeType = $maxPreview->getMimeType();
+		$imagick_mode = (bool)$this->config->getSystemValue('preview_use_imagick', false);
+		if ($imagick_mode && $mimeType !== null && extension_loaded('imagick')) {
+			switch ($mimeType) {
+				case 'image/jpeg':
+					$image = new OCPImage_JPEG();
+					break;
+				default:
+					$image = new OCPImage();
+			}
+		} else {
+			$image = new OCPImage();
+		}
 		$image->loadFromData($maxPreview->getContent());
 		return $image;
 	}

--- a/lib/private/Preview/Image.php
+++ b/lib/private/Preview/Image.php
@@ -59,5 +59,4 @@ abstract class Image extends ProviderV2 {
 		}
 		return null;
 	}
-
 }

--- a/lib/private/Preview/JPEG.php
+++ b/lib/private/Preview/JPEG.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @copyright Copyright (c) 2019, ownCloud, Inc.
  *
- * @author Olivier Paroz <github@oparoz.com>
+ * @author Ignacio Nunez <nachoparker@ownyourbits.com>
  *
  * @license AGPL-3.0
  *
@@ -22,11 +22,258 @@
 
 namespace OC\Preview;
 
+use Imagick;
+use OCP\ILogger;
+
 class JPEG extends Image {
 	/**
 	 * {@inheritDoc}
 	 */
 	public function getMimeType(): string {
 		return '/image\/jpeg/';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getThumbnail($path, $maxX, $maxY, $scalingup, $fileview) {
+		$imagick_mode = (bool)\OC::$server->getConfig()->getSystemValue('preview_use_imagick', false);
+		if (!$imagick_mode || !extension_loaded('imagick')) {
+			return parent::getThumbnail($path, $maxX, $maxY, $scalingup, $fileview);
+		}
+
+		$tmpPath = $fileview->toTmpFile($path);
+		if (!$tmpPath) {
+			return false;
+		}
+
+		// Creates \Imagick object from the JPG file
+		try {
+			$bp = $this->getResizedPreview($tmpPath, $maxX, $maxY);
+		} catch (\Exception $e) {
+			\OC::$server->getLogger()->logException($e, [
+				'message' => 'File: ' . $fileview->getAbsolutePath($path) . ' Imagick says:',
+				'level' => ILogger::ERROR,
+				'app' => 'core',
+			]);
+			return false;
+		}
+
+		unlink($tmpPath);
+
+		//new bitmap image object
+		$image = new OC_Image_JPEG();
+		$image->loadFromData($bp->getImageBlob());
+		//check if image object is valid
+		return $image->valid() ? $image : false;
+	}
+
+	/**
+	 * Returns a preview of maxX times maxY dimensions in JPG format
+	 *
+	 * @param string $tmpPath the location of the file to convert
+	 * @param int $maxX
+	 * @param int $maxY
+	 *
+	 * @return \Imagick
+	 */
+	private function getResizedPreview($tmpPath, $maxX, $maxY) {
+		$config = \OC::$server->getConfig();
+		$bp = new Imagick();
+
+		$bp->readImage($tmpPath);
+
+		$threads = (int)$config->getSystemValue('preview_thread_limit', 1);
+		if ($threads != -1) {
+			$bp->setResourceLimit(imagick::RESOURCETYPE_THREAD, $threads);
+		}
+		$quality = (int)$config->getSystemValue('jpeg_quality', 90);
+		if ($quality !== null) {
+			$quality = min(100, max(10, (int) $quality));
+		}
+		$bp->setImageCompressionQuality($quality);
+		$bp->setImageFormat('jpg');
+		$bp = $this->resize($bp, $maxX, $maxY);
+
+		return $bp;
+	}
+
+	/**
+	 * Returns a resized \Imagick object
+	 *
+	 * If you want to know more on the various methods available to resize an
+	 * image, check out this link : @link https://stackoverflow.com/questions/8517304/what-the-difference-of-sample-resample-scale-resize-adaptive-resize-thumbnail-im
+	 *
+	 * @param \Imagick $bp
+	 * @param int $maxX
+	 * @param int $maxY
+	 *
+	 * @return \Imagick
+	 */
+	private function resize($bp, $maxX, $maxY) {
+		list($previewWidth, $previewHeight) = array_values($bp->getImageGeometry());
+
+		// We only need to resize a preview which doesn't fit in the maximum dimensions
+		if ($previewWidth > $maxX || $previewHeight > $maxY) {
+			$interpolate = (bool)\OC::$server->getConfig()->getSystemValue('preview_interpolate', false);
+			if ($interpolate) {
+				$bp->resizeImage($maxX, $maxY, imagick::FILTER_CATROM, 1, true);
+			} else {
+				$bp->scaleImage($maxX, $maxY, true);
+			}
+		}
+
+		return $bp;
+	}
+}
+
+// TODO move to a new file
+class OC_Image_JPEG extends \OC_Image {
+
+	/** @var string */
+	protected $mimeType = 'image/jpeg';
+
+	/**
+	 * Loads an image from a string of data.
+	 *
+	 * @param string $str A string of image data as read from a file.
+	 * @return bool|resource An image resource or false on error
+	 */
+	public function loadFromData($str) {
+		$bp = new Imagick();
+		try {
+			$bp->readImageBlob($str);
+		} catch (\Exception $e) {
+			$this->logger->error('OC_Image_JPEG->loadFromData. Error loading image.', array('app' => 'core'));
+			return false;
+		}
+		$threads = (int)$this->config->getSystemValue('preview_thread_limit', 1);
+		if ($threads != 0) {
+			$bp->setResourceLimit(imagick::RESOURCETYPE_THREAD, $threads);
+		}
+		$bp->setImageFormat('jpg');
+		$this->resource = $bp;
+		return $this->resource;
+	}
+
+	/**
+	 * @return null|string Returns the raw image data.
+	 */
+	public function data() {
+		if (!$this->valid()) {
+			return null;
+		}
+		try {
+			$quality = $this->getJpegQuality();
+			$this->resource->setImageCompressionQuality($quality);
+			$data = $this->resource->getImageBlob();
+		} catch (\Exception $e) {
+			$this->logger->error('OC_Image_JPEG->data. Error getting image data.', array('app' => 'core'));
+		}
+		return $data;
+	}
+	/**
+	 * Determine whether the object contains an image resource.
+	 *
+	 * @return bool
+	 */
+	public function valid() { // apparently you can't name a method 'empty'...
+		return $this->resource->valid();
+	}
+
+	/**
+	 * Destroys the current image and resets the object
+	 */
+	public function destroy() {
+		if ($this->valid()) {
+			$this->resource->clear();
+		}
+		$this->resource = null;
+	}
+
+	public function __destruct() {
+		$this->destroy();
+	}
+
+	/**
+	 * Returns the width of the image or -1 if no image is loaded.
+	 *
+	 * @return int
+	 */
+	public function width() {
+		return $this->valid() ? $this->resource->getImageWidth() : -1;
+	}
+
+	/**
+	 * Returns the height of the image or -1 if no image is loaded.
+	 *
+	 * @return int
+	 */
+	public function height() {
+		return $this->valid() ? $this->resource->getImageHeight() : -1;
+	}
+
+	/**
+	 * Resizes the image preserving ratio.
+	 *
+	 * @param integer $maxSize The maximum size of either the width or height.
+	 * @return bool
+	 */
+	public function resize($maxSize) {
+		if (!$this->valid()) {
+			$this->logger->error(__METHOD__ . '(): No image loaded', array('app' => 'core'));
+			return false;
+		}
+		$widthOrig = $this->resource->getImageWidth();
+		$heightOrig = $this->resource->getImageHeight();
+		$ratioOrig = $widthOrig / $heightOrig;
+
+		if ($ratioOrig > 1) {
+			$newHeight = round($maxSize / $ratioOrig);
+			$newWidth = $maxSize;
+		} else {
+			$newWidth = round($maxSize * $ratioOrig);
+			$newHeight = $maxSize;
+		}
+
+		$this->preciseResize((int)round($newWidth), (int)round($newHeight));
+		return true;
+	}
+
+	/**
+	 * @param int $width
+	 * @param int $height
+	 * @return bool
+	 */
+	public function preciseResize(int $width, int $height): bool {
+		if (!$this->valid()) {
+			$this->logger->error(__METHOD__ . '(): No image loaded', array('app' => 'core'));
+			return false;
+		}
+		$interpolate = (bool)$this->config->getSystemValue('preview_interpolate', false);
+		if ($interpolate) {
+			$this->resource->resizeImage($width, $height, imagick::FILTER_CATROM, 1, true);
+		} else {
+			$this->resource->scaleImage($width, $height, true);
+		}
+		return true;
+	}
+
+	/**
+	 * Crops the image from point $x$y with dimension $wx$h.
+	 *
+	 * @param int $x Horizontal position
+	 * @param int $y Vertical position
+	 * @param int $w Width
+	 * @param int $h Height
+	 * @return bool for success or failure
+	 */
+	public function crop(int $x, int $y, int $w, int $h): bool {
+		if (!$this->valid()) {
+			$this->logger->error(__METHOD__ . '(): No image loaded', array('app' => 'core'));
+			return false;
+		}
+		$this->resource->cropImage($w, $h, $x, $y);
+		return true;
 	}
 }

--- a/lib/private/Preview/JPEG.php
+++ b/lib/private/Preview/JPEG.php
@@ -2,6 +2,7 @@
 /**
  * @copyright Copyright (c) 2019, ownCloud, Inc.
  *
+ * @author Olivier Paroz <github@oparoz.com>
  * @author Ignacio Nunez <nachoparker@ownyourbits.com>
  *
  * @license AGPL-3.0

--- a/lib/private/legacy/image.php
+++ b/lib/private/legacy/image.php
@@ -892,7 +892,12 @@ class OC_Image implements \OCP\IImage {
 			imagesavealpha($process, true);
 		}
 
-		imagecopyresampled($process, $this->resource, 0, 0, 0, 0, $width, $height, $widthOrig, $heightOrig);
+		$interpolate = (bool)$this->config->getSystemValue('preview_interpolate', false);
+		if ($interpolate) {
+			imagecopyresampled($process, $this->resource, 0, 0, 0, 0, $width, $height, $widthOrig, $heightOrig);
+		} else {
+			imagecopyresized($process, $this->resource, 0, 0, 0, 0, $width, $height, $widthOrig, $heightOrig);
+		}
 		if ($process == false) {
 			$this->logger->error(__METHOD__ . '(): Error re-sampling process image', array('app' => 'core'));
 			imagedestroy($process);
@@ -950,7 +955,12 @@ class OC_Image implements \OCP\IImage {
 			imagesavealpha($process, true);
 		}
 
-		imagecopyresampled($process, $this->resource, 0, 0, $x, $y, $targetWidth, $targetHeight, $width, $height);
+		$interpolate = (bool)$this->config->getSystemValue('preview_interpolate', false);
+		if ($interpolate) {
+			imagecopyresampled($process, $this->resource, 0, 0, $x, $y, $targetWidth, $targetHeight, $width, $height);
+		} else {
+			imagecopyresized($process, $this->resource, 0, 0, $x, $y, $targetWidth, $targetHeight, $width, $height);
+		}
 		if ($process == false) {
 			$this->logger->error('OC_Image->centerCrop, Error re-sampling process image ' . $width . 'x' . $height, array('app' => 'core'));
 			imagedestroy($process);

--- a/lib/private/legacy/image.php
+++ b/lib/private/legacy/image.php
@@ -56,9 +56,9 @@ class OC_Image implements \OCP\IImage {
 	/** @var finfo */
 	private $fileInfo;
 	/** @var \OCP\ILogger */
-	private $logger;
+	protected $logger;
 	/** @var \OCP\IConfig */
-	private $config;
+	protected $config;
 	/** @var array */
 	private $exif;
 


### PR DESCRIPTION
This PR is a PoC that introduces the option of using Imagick for JPEG images in the previews engine.

### Motivation 

See this [blog post](https://ownyourbits.com/2019/06/29/understanding-and-improving-nextcloud-previews/).

There are two main areas where we could try to work to optimize tis

- Preview generation (this PR)
- Access to the already generated thumbnails -> https://github.com/nextcloud/server/pull/14953

### Description

This is an attempt at improving this situation through a combination of
- Nextcloud server changes (this PR)
- Preview Generator changes (this other PR -> https://github.com/nachoparker/previewgenerator/pull/1)
- Proper configuration of the preview generator to generate the sizes that Files and Gallery really use.
- New switches to allow fine grained control of quality, image size, filters used and so on.

This PR would be part number one of said attempt.

The main attractive of imagick in native multithreaded execution if compiled with openMP (the default at least in Debian).

Since we are not interested in implementing everything from scratch but only try to improve the most performance sensitive areas, I have extended `OC_Image` with a new class that over-rides some if its methods.

Since there are [concerns](https://github.com/nextcloud/server/issues/13099) about using imagick at all and in order to allow flexibility this new mechanism is optional. It can be enabled and tweaked through config options.

```
  'preview_use_imagick' => true,
  'preview_interpolate' => false,
  'preview_thread_limit' => 8,
```

`preview_use_imagick = false` or the lack of `php-imagick` revert to the old behavior using GD. Also we allow to disable interpolation to achieve faster previews, which in my opinion is mostly OK since it doesn't matter that much for small thumbnails. An alternative option is to only enable interpolation for the `max` preview (the one that shows big if you click on it in the gallery).

### Goal

Generate the previews as fast as possible without sacrificing much quality.

### Testing procedure

I tested these changes with a dataset comprised of 1.5GiB of high quality photos (~100 x 15MiB photos) on a 16 core x86 machine with 64MiB of RAM.

For the reasons stated above, I ran the tests with the following configuration

```
occ config:app:set previewgenerator squareSizes --value="32 256"                                                                                                                                                                                                                                                               
occ config:app:set previewgenerator widthSizes  --value="256 384"
occ config:app:set previewgenerator heightSizes --value="256"
occ config:system:set preview_max_x --value 2048
occ config:system:set preview_max_y --value 2048
```

All the files are already uploaded. The preview cache is cleaned every run with

```
rm -r data/appdata_*/preview/*
occ files:scan-app-data
```

In Imagick we are using a CATROM filter.

### Results

| Method          | Processes | Threads | Interpolate | JPEG quality | Time | % of initial (proposed config) | % of initial (default config) |
|-----------------|-----------|---------|-------------|--------------|------|--------------|--------------|
| GD (*)  | 1         | 1       | yes         | 90           | 7m16 | -            |-            |
| GD  | 1         | 1       | yes         | 90           | 1m50 | -            |25%            |
| GD  | 1         | 1       | yes         | 60           | 1m50 | -            | 25%           |
| GD  | 1         | 1       | no (**)        | 90           | 48s | 43%            | 11%            |
| GD  | 1         | 1       | no (**)        | 60           | 48s | 43%            | 11%            |
| Imagick         | 1         | 1       | yes         | 90           | 1m53 | 102%         | 25%         |
| Imagick         | 1         | 1       | yes         | 60           | 1m51 | 100%         | 25%         |
| Imagick         | 1         | 1       | no          | 90           | 1m26 | 78%          | 19%          |
| Imagick         | 1         | 1       | no          | 60           | 1m23 | 75%          | 19%          |
| Imagick         | 1         | 16      | yes         | 90           | 1m18 | 71%          | 15%          |
| Imagick         | 1         | 16      | yes         | 60           | 1m22 | 74%          | 18%          |
|-----------------|-----------|---------|-------------|--------------|------|----------|----------|
| GD  | 4         | 1       | yes         | 60           | 28s  | 25%          | 6%          |
| Imagick         | 4         | 1       | no          | 90           | 23s  | 20%          | 5%          |
| Imagick         | 4         | 1       | no          | 60           | 22s  | 20%          | 5%          |
| GD  | 16        | 1       | yes         | 60           | 12s  | 11%          | 3%          |
| Imagick         | 16        | 1       | no          | 90           | 10s  | 9%           | 2%           |
| Imagick         | 16        | 1       | no          | 60           | 10s  | 9%           | 2%           |

(*) Default settings: 4096x4096 Max preview, all sizes enabled
(**) Awful, unacceptable quality

The multi-process tests (bottom half) are run using the modified Preview Generator -> https://github.com/nachoparker/previewgenerator/pull/1

### Conclusions

Imagick can outperform GD while retaining decent quality mainly due to the fact that is multi-threaded. Still the big bottleneck is in the PHP non native part. In order to improve that something like https://github.com/nextcloud/server/pull/14953 would need to be implemented, or maybe try to optimize the current Previews code flow.

Since this is the case, better results are achieved by using the "multi-process" approach (https://github.com/nachoparker/previewgenerator/pull/1). Even without server modifications, using the traditional GD method we can achieve a 4x speed boost, which would be 5x with Imagick (with the proposed settings).

Just configuring the Preview Generator properly will imply a 4x speed boost and lots of space saved without any other changes.

JPEG quality barely affects performance, but it mostly only affects storage space.

With these changes the user has more options to tweak performance according to their preferences and how powerful their machine is.

### Future work

- Study generating the images in the upload hook with multiple threads so we don't need the preview generator cron job.
- Modify Preview Generator to spawn multiple threads using `pthreads` or `parallel` once there are ZTS PHP packages available ([link](https://github.com/oerdnj/deb.sury.org/issues/327) [link](https://github.com/oerdnj/deb.sury.org/issues/491)) instead of relying on an external script that launches several processes in parallel.

Signed-off-by: nachoparker <nacho@ownyourbits.com>